### PR TITLE
Scripts and README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ npm run-script build
 
 ## Tests
 
-To launch the test suite, make sure you have already installed the dependencies using ````npm-install````.
+To launch the test suite, make sure you have already installed the dependencies using ````npm install````.
 Tests are launching in all your installed browsers. They're also launched on Travis CI, in PhantomJS.
 
 ````

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
     "name": "basil.js",
     "version": "0.3.2",
     "scripts": {
-        "test": "./node_modules/karma/bin/karma start test/karma.config.js",
-        "build": "./node_modules/gulp/bin/gulp.js"
+        "test": "node node_modules/karma/bin/karma start test/karma.config.js",
+        "build": "node node_modules/gulp/bin/gulp.js"
     },
     "dependencies": {},
     "devDependencies": {


### PR DESCRIPTION
The scripts defined in package.json run on Linux, but they fail on Windows as it cannot resolve the path. I have changed it so it could run on both the platforms.

Fixed a typo in README, changed npm-install to npm install at line 92
