### PR TITLE
Add spm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
         "gulp": "*",
         "gulp-uglify": "*",
         "gulp-rename": "*"
+    },
+    "spm": {
+        "main": "src/basil.js"
     }
 }


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/basil.js

---

It is a package manager based on [Sea.js](https://github.com/seajs/seajs) which is a popular module loader in China.

spmjs focus in browser side. We supply a complete lifecycle managment of package by using [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of basil.js in spmjs, I can add it for your account after signing in http://spmjs.io.
