### PR TITLE
Add options.keyDelimiter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ options = {
   // default: 365
   expireDays: 31
 
+  // keyDelimiter. The value used delimt the namespace from the key name
+  // default: '.'
+  keyDelimiter: '.'
+
 };
 ```
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
         "karma-phantomjs-launcher": "*",
         "gulp": "*",
         "gulp-uglify": "*",
-        "gulp-rename": "*"
+        "gulp-rename": "*",
+        "mocha": "*"
     },
     "spm": {
         "main": "src/basil.js"

--- a/src/basil.js
+++ b/src/basil.js
@@ -66,7 +66,8 @@
 	Basil.options = Basil.utils.extend({
 		namespace: 'b45i1',
 		storages: ['local', 'cookie', 'session', 'memory'],
-		expireDays: 365
+		expireDays: 365,
+		keyDelimiter: '.'
 	}, window.Basil ? window.Basil.options : {});
 
 	// Storage
@@ -84,20 +85,20 @@
 					return storages;
 				return Basil.utils.isString(storages) ? [storages] : [];
 			},
-			_toStoredKey = function (namespace, path) {
+			_toStoredKey = function (namespace, path, delimiter) {
 				var key = '';
 				if (_isValidKey(path)) {
 					key += path;
 				} else if (Basil.utils.isArray(path)) {
 					path = Basil.utils.isFunction(path.filter) ? path.filter(_isValidKey) : path;
-					key = path.join('.');
+					key = path.join(delimiter);
 				}
-				return key && _isValidKey(namespace) ? namespace + '.' + key : key;
+				return key && _isValidKey(namespace) ? namespace + delimiter + key : key;
  			},
-			_toKeyName = function (namespace, key) {
+			_toKeyName = function (namespace, key, delimiter) {
 				if (!_isValidKey(namespace))
 					return key;
-				return key.replace(new RegExp('^' + namespace + '.'), '');
+				return key.replace(new RegExp('^' + namespace + delimiter), '');
 			},
 			_toStoredValue = function (value) {
 				return JSON.stringify(value);
@@ -138,12 +139,12 @@
 					}
 				}
 			},
-			keys: function (namespace) {
+			keys: function (namespace, delimiter) {
 				var keys = [];
 				for (var i = 0, key; i < window[this.engine].length; i++) {
 					key = window[this.engine].key(i);
 					if (!namespace || key.indexOf(namespace) === 0)
-						keys.push(_toKeyName(namespace, key));
+						keys.push(_toKeyName(namespace, key, delimiter));
 				}
 				return keys;
 			}
@@ -181,11 +182,11 @@
 						this.remove(key);
 				}
 			},
-			keys: function (namespace) {
+			keys: function (namespace, delimiter) {
 				var keys = [];
 				for (var key in this._hash)
 					if (!namespace || key.indexOf(namespace) === 0)
-						keys.push(_toKeyName(namespace, key));
+						keys.push(_toKeyName(namespace, key, delimiter));
 				return keys;
 			}
 		};
@@ -260,7 +261,7 @@
 						this.remove(key);
 				}
 			},
-			keys: function (namespace) {
+			keys: function (namespace, delimiter) {
 				if (!this.check())
 					throw Error('cookies are disabled');
 				var keys = [],
@@ -269,7 +270,7 @@
 					cookie = cookies[i].replace(/^\s*/, '');
 					key = decodeURIComponent(cookie.substr(0, cookie.indexOf('=')));
 					if (!namespace || key.indexOf(namespace) === 0)
-						keys.push(_toKeyName(namespace, key));
+						keys.push(_toKeyName(namespace, key, delimiter));
 				}
 				return keys;
 			}
@@ -293,7 +294,7 @@
 			},
 			set: function (key, value, options) {
 				options = Basil.utils.extend({}, this.options, options);
-				if (!(key = _toStoredKey(options.namespace, key)))
+				if (!(key = _toStoredKey(options.namespace, key, options.keyDelimiter)))
 					return false;
 				value = options.raw === true ? value : _toStoredValue(value);
 				var where = null;
@@ -316,7 +317,7 @@
 			},
 			get: function (key, options) {
 				options = Basil.utils.extend({}, this.options, options);
-				if (!(key = _toStoredKey(options.namespace, key)))
+				if (!(key = _toStoredKey(options.namespace, key, options.keyDelimiter)))
 					return null;
 				var value = null;
 				Basil.utils.tryEach(_toStoragesArray(options.storages), function (storage, index) {
@@ -331,7 +332,7 @@
 			},
 			remove: function (key, options) {
 				options = Basil.utils.extend({}, this.options, options);
-				if (!(key = _toStoredKey(options.namespace, key)))
+				if (!(key = _toStoredKey(options.namespace, key, options.keyDelimiter)))
 					return;
 				Basil.utils.tryEach(_toStoragesArray(options.storages), function (storage) {
 					_storages[storage].remove(key);
@@ -354,7 +355,7 @@
 				options = Basil.utils.extend({}, this.options, options);
 				var map = {};
 				Basil.utils.tryEach(_toStoragesArray(options.storages), function (storage) {
-					Basil.utils.each(_storages[storage].keys(options.namespace), function (key) {
+					Basil.utils.each(_storages[storage].keys(options.namespace, options.keyDelimiter), function (key) {
 						map[key] = Basil.utils.isArray(map[key]) ? map[key] : [];
 						map[key].push(storage);
 					}, this);

--- a/test/test.js
+++ b/test/test.js
@@ -199,6 +199,33 @@
 				basil.reset({ namespace: 'n2' });
 				basil.reset({ namespace: 'n3' });
 			});
+			it('should be able to get all the keys of a given namespace and delimiter', function() {
+				var basil = new window.Basil();
+
+				basil.options.keyDelimiter = ':';
+
+				basil.options.namespace = 'n1';
+				basil.set('foo', 'i am local with namespace `n1`', { storages: ['local'] });
+				basil.set('foo', 'i am session with namespace `n1`', { storages: ['session'] });
+				basil.options.namespace = 'n2';
+				basil.set('bar', 'i am cookie and session with namespace `n2`', { storages: ['cookie', 'session'] });
+				basil.set('baz', 'i am session with namespace `n2`', { storages: ['session'] });
+				basil.options.namespace = 'n3';
+				expect(basil.keys({ namespace: 'n1' })).to.eql(['foo']);
+				expect(basil.keysMap({ namespace: 'n1' })).to.eql({
+					'foo': ['local', 'session'],
+				});
+				expect(basil.keys({ namespace: 'n2' })).to.eql(['bar', 'baz']);
+				expect(basil.keysMap({ namespace: 'n2' })).to.eql({
+					'bar': ['cookie'],
+					'baz': ['session']
+				});
+				expect(basil.keys({ namespace: 'n3' })).to.eql([]);
+				expect(basil.keysMap({ namespace: 'n3' })).to.eql({});
+				basil.reset({ namespace: 'n1' });
+				basil.reset({ namespace: 'n2' });
+				basil.reset({ namespace: 'n3' });
+			});
 		});
 
 		if (window.Basil.cookie.check()) {


### PR DESCRIPTION
Expose the ability to programmatically set the delimiter, but keep it backwards compatible with the existing API using `.` as the delimiter.

Also, I added in `mocha` as a dependency since when I pulled down and `npm install && npm test` I got a `missing "mocha" dependency` error.